### PR TITLE
Fixes a bug with the IR-Led switch in Camera Controls menu.

### DIFF
--- a/firmware_mod/v2/scripts/common_functions.sh
+++ b/firmware_mod/v2/scripts/common_functions.sh
@@ -87,19 +87,19 @@ yellow_led(){
 ir_led(){
   case "$1" in
   on)
-    setgpio 49 0
+    setgpio 49 1
     ;;
   off)
-    setgpio 49 1
+    setgpio 49 0
     ;;
   status)
     status=$(getgpio 49)
     case $status in
       0)
-        echo "ON"
+        echo "OFF"
         ;;
       1)
-        echo "OFF"
+        echo "ON"
       ;;
     esac
   esac

--- a/firmware_mod/v2/www/cgi-bin/action.cgi
+++ b/firmware_mod/v2/www/cgi-bin/action.cgi
@@ -69,11 +69,11 @@ if [ -n "$F_cmd" ]; then
     ;;
 
     ir_led_on)
-      setgpio 49 0
+      setgpio 49 1
     ;;
 
     ir_led_off)
-      setgpio 49 1
+      setgpio 49 0
     ;;
 
     ir_cut_on)

--- a/firmware_mod/v2/www/cgi-bin/api.cgi
+++ b/firmware_mod/v2/www/cgi-bin/api.cgi
@@ -173,11 +173,11 @@ if [ -n "$F_action" ]; then
     getReturn 1234 "success" "Yellow LED is Off."
     ;;
   ir_led_on)
-    setGpio 49 0
+    setGpio 49 1
     getReturn 1234 "success" "IR LED is On."
     ;;
   ir_led_off)
-    setGpio 49 1
+    setGpio 49 0
     getReturn 1234 "success" "IR LED is Off."
     ;;
   ir_cut_on)


### PR DESCRIPTION
Fix for Issue: #43
GPIO 49 is twisted on WYZE v2
0 => LED OFF
1 => LED ON